### PR TITLE
quoted filename argument to handle spaces

### DIFF
--- a/overcast-upload.sh
+++ b/overcast-upload.sh
@@ -65,7 +65,7 @@ key=$(grep -o -E \
   's/data-key-prefix="//g' \
   )
 
-filename=$(basename $1)
+filename=$(basename "$1")
 
 if [[ -z "$policy" ]] \
   || [[ -z "$signature" ]] \


### PR DESCRIPTION
Previously, filenames with spaces broke the upload, even if the filename was quoted.  This fixes that.